### PR TITLE
feat: Add job priority

### DIFF
--- a/examples/ecto_job_priority_demo/.formatter.exs
+++ b/examples/ecto_job_priority_demo/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/examples/ecto_job_priority_demo/.gitignore
+++ b/examples/ecto_job_priority_demo/.gitignore
@@ -1,0 +1,24 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where 3rd-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+ecto_job_priority_demo-*.tar
+

--- a/examples/ecto_job_priority_demo/Makefile
+++ b/examples/ecto_job_priority_demo/Makefile
@@ -1,0 +1,8 @@
+start_db:
+	docker-compose -f docker-compose-test.yml up -d
+
+migrate:
+	mix do ecto.create, ecto.migrate
+
+run:
+	iex -S mix

--- a/examples/ecto_job_priority_demo/README.md
+++ b/examples/ecto_job_priority_demo/README.md
@@ -1,0 +1,38 @@
+# EctoJobPriorityDemo
+
+This demo application shows EctoJob in action with different priorities in the same queue.
+
+## How it works
+
+There are three GenServers adding the same quantity of Ecto Jobs with different priorities after every 5 seconds. The Job with higher priority takes more time to execute than the others to make clear that the priority is respected.
+
+```elixir
+  high_priority    = 100 - (0 * 50) = 100 |> Process.sleep()
+  regular_priority = 100 - (1 * 50) = 50 |> Process.sleep()
+  low_priority     = 100 - (2 * 50) = 0 |> Process.sleep()
+```
+
+The default value of priority is `0`. To decrease the priority you must increase its value.
+
+As you will see even the faster jobs are executed later if configured with low priority.
+
+### Setup Postgresql
+
+To start up the docker-compose postgresql service:
+```bash
+make start_db
+```
+
+### Setup Database
+
+To run the project migration:
+```bash
+make migrate
+```
+
+### Running the application
+
+To run the project:
+```bash
+make run
+```

--- a/examples/ecto_job_priority_demo/config/config.exs
+++ b/examples/ecto_job_priority_demo/config/config.exs
@@ -1,0 +1,20 @@
+# This file is responsible for configuring your application
+# and its dependencies with the aid of the Mix.Config module.
+use Mix.Config
+
+config :logger, :level, :info
+
+config :ecto_job_priority_demo, ecto_repos: [EctoJobPriorityDemo.Repo]
+
+config :ecto_job_priority_demo, EctoJobPriorityDemo.Repo,
+  adapter: Ecto.Adapters.Postgres,
+  username: "postgres",
+  password: "password",
+  database: "ecto_job_test",
+  hostname: "localhost",
+  pool_size: 30
+
+config :ecto_job,
+  repo: EctoJobPriorityDemo.Repo,
+  always_dispatch_jobs_on_poll: true,
+  log: false

--- a/examples/ecto_job_priority_demo/docker-compose-test.yml
+++ b/examples/ecto_job_priority_demo/docker-compose-test.yml
@@ -1,0 +1,11 @@
+version: '2'
+
+services:
+  ecto-job-test:
+    image: postgres:9.6-alpine
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=password
+      - POSTGRES_DB=ecto_job_test

--- a/examples/ecto_job_priority_demo/lib/ecto_job_priority_demo.ex
+++ b/examples/ecto_job_priority_demo/lib/ecto_job_priority_demo.ex
@@ -1,0 +1,109 @@
+defmodule EctoJobPriorityDemo do
+  @moduledoc false
+  use GenServer
+
+  alias EctoJobPriorityDemo.JobMonitor
+  alias EctoJobPriorityDemo.JobQueue
+  alias EctoJobPriorityDemo.Repo
+
+  require Logger
+
+  @high_priority 0
+  @regular_priority 1
+  @low_priority 2
+
+  def start_link(jobs \\ %{}) do
+    GenServer.start_link(__MODULE__, jobs, name: __MODULE__)
+  end
+
+  def init(_) do
+    period = 5000
+    count = 500
+
+    {:ok, low_priority} =
+      JobMonitor.start_link(
+        %{count: count, priority: @low_priority, period: period},
+        :low_priority
+      )
+
+    {:ok, regular_priority} =
+      JobMonitor.start_link(
+        %{count: count, priority: @regular_priority, period: period},
+        :regular_priority
+      )
+
+    {:ok, high_priority} =
+      JobMonitor.start_link(
+        %{count: count, priority: @high_priority, period: period},
+        :high_priority
+      )
+
+    state = %{
+      high_priority: high_priority,
+      regular_priority: regular_priority,
+      low_priority: low_priority
+    }
+
+    Logger.info("Jobs monitor started")
+
+    send(self(), {:notify_jobs})
+    {:ok, state}
+  end
+
+  def resolve(priority) do
+    GenServer.cast(__MODULE__, {:resolve, priority})
+  end
+
+  # Server
+
+  def handle_info({:notify_jobs}, state) do
+    %{
+      high_priority: high_priority,
+      regular_priority: regular_priority,
+      low_priority: low_priority
+    } = state
+
+    high_priority_value =
+      high_priority
+      |> JobMonitor.count()
+
+    regular_priority_value =
+      regular_priority
+      |> JobMonitor.count()
+
+    low_priority_value =
+      low_priority
+      |> JobMonitor.count()
+
+    Logger.info(
+      "high_priority: #{inspect(high_priority_value)}, regular_priority: #{
+        inspect(regular_priority_value)
+      }, low_priority: #{inspect(low_priority_value)}"
+    )
+
+    Process.send_after(self(), {:notify_jobs}, 100)
+    {:noreply, state}
+  end
+
+  def handle_cast({:resolve, priority}, state) do
+    state
+    |> update_jobs(priority, -1)
+
+    {:noreply, state}
+  end
+
+  defp update_jobs(%{high_priority: high_priority}, @high_priority, value) do
+    high_priority
+    |> JobMonitor.update(value)
+  end
+
+  defp update_jobs(%{regular_priority: regular_priority}, @regular_priority, value) do
+    regular_priority
+    |> JobMonitor.update(value)
+  end
+
+  defp update_jobs(%{low_priority: low_priority}, @low_priority, value) do
+    low_priority
+    |> JobMonitor.update(value)
+  end
+end

--- a/examples/ecto_job_priority_demo/lib/ecto_job_priority_demo/application.ex
+++ b/examples/ecto_job_priority_demo/lib/ecto_job_priority_demo/application.ex
@@ -1,0 +1,21 @@
+defmodule EctoJobPriorityDemo.Application do
+  # See https://hexdocs.pm/elixir/Application.html
+  # for more information on OTP Applications
+  @moduledoc false
+
+  use Application
+
+  def start(_type, _args) do
+    # List all child processes to be supervised
+    children = [
+      {EctoJobPriorityDemo.Repo, []},
+      {EctoJobPriorityDemo.JobQueue, [repo: EctoJobPriorityDemo.Repo, max_demand: 100]},
+      {EctoJobPriorityDemo, %{}}
+    ]
+
+    # See https://hexdocs.pm/elixir/Supervisor.html
+    # for other strategies and supported options
+    opts = [strategy: :one_for_one, name: EctoJobPriorityDemo.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+end

--- a/examples/ecto_job_priority_demo/lib/ecto_job_priority_demo/job_monitor.ex
+++ b/examples/ecto_job_priority_demo/lib/ecto_job_priority_demo/job_monitor.ex
@@ -1,0 +1,59 @@
+defmodule EctoJobPriorityDemo.JobMonitor do
+  @moduledoc false
+  use GenServer
+
+  alias EctoJobPriorityDemo.JobQueue
+  alias EctoJobPriorityDemo.Repo
+
+  def start_link(jobs \\ %{count: 1, priority: 0, period: 1000}, server) do
+    GenServer.start_link(__MODULE__, jobs, name: server)
+  end
+
+  def init(%{count: count, priority: priority, period: period}) do
+    send(self(), {:produce_jobs, count, priority, period})
+    {:ok, 0}
+  end
+
+  def update(server, value) do
+    GenServer.cast(server, {:update, value})
+  end
+
+  def count(server) do
+    GenServer.call(server, :count)
+  end
+
+  # Server
+
+  def handle_cast({:update, value}, state) do
+    {:noreply, state + value}
+  end
+
+  def handle_call(:count, _from, state) do
+    {:reply, state, state}
+  end
+
+  def handle_info({:produce_jobs, count, priority, period}, state) do
+    jobs =
+      Enum.map(1..count, fn _ ->
+        %{
+          state: "AVAILABLE",
+          expires: nil,
+          schedule: DateTime.utc_now(),
+          attempt: 0,
+          max_attempts: 5,
+          params: %{priority: priority},
+          notify: nil,
+          priority: priority,
+          updated_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second),
+          inserted_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+        }
+      end)
+
+    JobQueue
+    |> Repo.insert_all(jobs)
+
+    Process.send_after(self(), {:produce_jobs, count, priority, period}, period)
+
+    {:noreply, state + count}
+  end
+end

--- a/examples/ecto_job_priority_demo/lib/ecto_job_priority_demo/job_queue.ex
+++ b/examples/ecto_job_priority_demo/lib/ecto_job_priority_demo/job_queue.ex
@@ -1,0 +1,24 @@
+defmodule EctoJobPriorityDemo.JobQueue do
+  use EctoJob.JobQueue, table_name: "jobs"
+
+  def perform(multi, %{"priority" => priority}) do
+    multi
+    |> Ecto.Multi.run(:resolve, fn _repo, _changes ->
+      make_work_heavy(priority)
+      {:ok, EctoJobPriorityDemo.resolve(priority)}
+    end)
+    |> EctoJobPriorityDemo.Repo.transaction()
+  end
+
+  @doc """
+  This method make high priority jobs heavy
+
+  high_priority    = 100 - (0 * 50) = 100
+  regular_priority = 100 - (1 * 50) = 50
+  low_priority     = 100 - (2 * 50) = 0
+  """
+  defp make_work_heavy(priority) do
+    (100 - priority * 50)
+    |> Process.sleep()
+  end
+end

--- a/examples/ecto_job_priority_demo/lib/ecto_job_priority_demo/repo.ex
+++ b/examples/ecto_job_priority_demo/lib/ecto_job_priority_demo/repo.ex
@@ -1,0 +1,3 @@
+defmodule EctoJobPriorityDemo.Repo do
+  use Ecto.Repo, otp_app: :ecto_job_priority_demo, adapter: Ecto.Adapters.Postgres
+end

--- a/examples/ecto_job_priority_demo/mix.exs
+++ b/examples/ecto_job_priority_demo/mix.exs
@@ -1,0 +1,28 @@
+defmodule EctoJobPriorityDemo.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :ecto_job_priority_demo,
+      version: "0.1.0",
+      elixir: "~> 1.7",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  # Run "mix help compile.app" to learn about applications.
+  def application do
+    [
+      mod: {EctoJobPriorityDemo.Application, []},
+      extra_applications: [:logger]
+    ]
+  end
+
+  # Run "mix help deps" to learn about dependencies.
+  defp deps do
+    [
+      {:ecto_job, path: "../../"}
+    ]
+  end
+end

--- a/examples/ecto_job_priority_demo/mix.lock
+++ b/examples/ecto_job_priority_demo/mix.lock
@@ -1,0 +1,11 @@
+%{
+  "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm"},
+  "db_connection": {:hex, :db_connection, "2.1.0", "122e2f62c4906bf2e49554f1e64db5030c19229aa40935f33088e7d543aa79d0", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, repo: "hexpm", optional: false]}], "hexpm"},
+  "decimal": {:hex, :decimal, "1.8.0", "ca462e0d885f09a1c5a342dbd7c1dcf27ea63548c65a65e67334f4b61803822e", [:mix], [], "hexpm"},
+  "ecto": {:hex, :ecto, "3.1.7", "fa21d06ef56cdc2fdaa62574e8c3ba34a2751d44ea34c30bc65f0728421043e5", [:mix], [{:decimal, "~> 1.6", [hex: :decimal, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm"},
+  "ecto_sql": {:hex, :ecto_sql, "3.1.6", "1e80e30d16138a729c717f73dcb938590bcdb3a4502f3012414d0cbb261045d8", [:mix], [{:db_connection, "~> 2.0", [hex: :db_connection, repo: "hexpm", optional: false]}, {:ecto, "~> 3.1.0", [hex: :ecto, repo: "hexpm", optional: false]}, {:mariaex, "~> 0.9.1", [hex: :mariaex, repo: "hexpm", optional: true]}, {:myxql, "~> 0.2.0", [hex: :myxql, repo: "hexpm", optional: true]}, {:postgrex, "~> 0.14.0 or ~> 0.15.0", [hex: :postgrex, repo: "hexpm", optional: true]}, {:telemetry, "~> 0.4.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm"},
+  "gen_stage": {:hex, :gen_stage, "0.14.2", "6a2a578a510c5bfca8a45e6b27552f613b41cf584b58210f017088d3d17d0b14", [:mix], [], "hexpm"},
+  "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
+  "postgrex": {:hex, :postgrex, "0.14.3", "5754dee2fdf6e9e508cbf49ab138df964278700b764177e8f3871e658b345a1e", [:mix], [{:connection, "~> 1.0", [hex: :connection, repo: "hexpm", optional: false]}, {:db_connection, "~> 2.0", [hex: :db_connection, repo: "hexpm", optional: false]}, {:decimal, "~> 1.5", [hex: :decimal, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm"},
+  "telemetry": {:hex, :telemetry, "0.4.0", "8339bee3fa8b91cb84d14c2935f8ecf399ccd87301ad6da6b71c09553834b2ab", [:rebar3], [], "hexpm"},
+}

--- a/examples/ecto_job_priority_demo/priv/repo/migrations/20190714001622_create_job_queue.exs
+++ b/examples/ecto_job_priority_demo/priv/repo/migrations/20190714001622_create_job_queue.exs
@@ -1,0 +1,14 @@
+defmodule EctoJobPriorityDemo.Repo.Migrations.CreateJobQueue do
+  @moduledoc false
+  use Ecto.Migration
+
+  def up do
+    EctoJob.Migrations.Install.up()
+    EctoJob.Migrations.CreateJobTable.up("jobs")
+  end
+
+  def down do
+    EctoJob.Migrations.CreateJobTable.down("jobs")
+    EctoJob.Migrations.Install.down()
+  end
+end

--- a/examples/ecto_job_priority_demo/test/ecto_job_priority_demo_test.exs
+++ b/examples/ecto_job_priority_demo/test/ecto_job_priority_demo_test.exs
@@ -1,0 +1,8 @@
+defmodule EctoJobPriorityDemoTest do
+  use ExUnit.Case
+  doctest EctoJobPriorityDemo
+
+  test "greets the world" do
+    assert EctoJobPriorityDemo.hello() == :world
+  end
+end

--- a/examples/ecto_job_priority_demo/test/test_helper.exs
+++ b/examples/ecto_job_priority_demo/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/lib/ecto_job/migrations.ex
+++ b/lib/ecto_job/migrations.ex
@@ -87,6 +87,7 @@ defmodule EctoJob.Migrations do
           add(:max_attempts, :integer, null: false, default: 5)
           add(:params, :map, null: false)
           add(:notify, :string)
+          add(:priority, :integer, null: false, default: 0)
           timestamps(timestamp_opts)
         end
 
@@ -109,6 +110,33 @@ defmodule EctoJob.Migrations do
       prefix = Keyword.get(opts, :prefix)
       execute("DROP TRIGGER tr_notify_inserted_#{name} ON #{Helpers.qualify(name, prefix)}")
       execute("DROP TABLE #{Helpers.qualify(name, prefix)}")
+    end
+  end
+
+  defmodule AddPriorityToJobTable do
+    @moduledoc """
+    Defines a migration to add priority column to the job queue table.
+    This migration can be run multiple times with different values to update multiple queues.
+    """
+
+    import Ecto.Migration
+
+    @doc """
+    Add the priority column to the job queue table with the given name.
+    """
+    def up(name) do
+      alter table(name) do
+        add(:priority, :integer, null: false, default: 0)
+      end
+    end
+
+    @doc """
+    Drops the priority column from job queue table with the given name.
+    """
+    def down(name) do
+      alter table(name) do
+        remove(:priority)
+      end
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule EctoJob.Mixfile do
   use Mix.Project
 
-  @version "2.1.0"
+  @version "3.0.0"
   @url "https://github.com/mbuhot/ecto_job"
 
   def project do


### PR DESCRIPTION
Adds the possibility to control the **priority** of some jobs in the same queue. The default behavior is set up the same priority to all jobs.

The module `EctoJob.Migrations.AddPriorityToJobTable` permit to upgrade pre-existent job queue tables without side effects.